### PR TITLE
Update blum.py

### DIFF
--- a/utils/blum.py
+++ b/utils/blum.py
@@ -44,7 +44,12 @@ class BlumBot:
 
         r = await (await self.session.get("https://gateway.blum.codes/v1/friends/balance", proxy=self.proxy)).json()
         limit_invites = r.get('limitInvitation')
-        referral_link = 't.me/BlumCryptoBot/app?startapp=ref_' + r.get('referralToken')
+        referral_token = r.get('referralToken')
+        if referral_token is not None:
+            referral_link = 't.me/BlumCryptoBot/app?startapp=ref_' + referral_token
+        else:
+            logger.error(f"Thread {self.thread} | Referral token is None")
+            referral_link = None
 
         await asyncio.sleep(random.uniform(5, 7))
 


### PR DESCRIPTION
**Description**
This pull request fixes an issue where the code attempts to concatenate a string with a None value, resulting in a TypeError. Specifically, the method r.get('referralToken') can return None, which cannot be concatenated with a string in Python.

**Fix**
The solution is to add a check to ensure the value of referralToken exists before attempting to concatenate it with the string. If referralToken is None, the code will handle it appropriately, avoiding the TypeError.

**Changes**
Added a check for referralToken in the stats method.
Included logging for instances where referralToken is None to aid in debugging.
Impact
This fix prevents the script from crashing due to a TypeError when referralToken is None, ensuring smoother execution and better error handling.